### PR TITLE
fix outofplace word checking

### DIFF
--- a/src/lib/Wordle.test.ts
+++ b/src/lib/Wordle.test.ts
@@ -135,6 +135,38 @@ describe("validateWord", () => {
     ]
     expect(validateWord(input, solution)).toEqual(expectedOutput)
   })
+
+  describe("edge cases", () => {
+    it("mark only one character to be out of place", () => {
+      const input = "อัศจรรย์"
+      const solution = "ประเทศ"
+
+      const expectedOutput = [
+        { correct: CharState.Wrong, char: "อั" },
+        { correct: CharState.OutOfPlace, char: "ศ" },
+        { correct: CharState.Wrong, char: "จ" },
+        { correct: CharState.OutOfPlace, char: "ร" },
+        { correct: CharState.Wrong, char: "ร" },
+        { correct: CharState.Wrong, char: "ย์" },
+      ]
+      expect(validateWord(input, solution)).toEqual(expectedOutput)
+    })
+
+    it("mark two of the same characters to be out of place", () => {
+      const input = "อัศจรรย์"
+      const solution = "ปรรเทศ"
+
+      const expectedOutput = [
+        { correct: CharState.Wrong, char: "อั" },
+        { correct: CharState.OutOfPlace, char: "ศ" },
+        { correct: CharState.Wrong, char: "จ" },
+        { correct: CharState.OutOfPlace, char: "ร" },
+        { correct: CharState.OutOfPlace, char: "ร" },
+        { correct: CharState.Wrong, char: "ย์" },
+      ]
+      expect(validateWord(input, solution)).toEqual(expectedOutput)
+    })
+  })
 })
 
 describe("layout", () => {

--- a/src/lib/Wordle.test.ts
+++ b/src/lib/Wordle.test.ts
@@ -100,7 +100,7 @@ describe("validateWord", () => {
 
     const expectedOutput = [
       { correct: CharState.Wrong, char: "x" },
-      { correct: CharState.OutOfPlace, char: "จ" },
+      { correct: CharState.OutOfPlace, char: "จั" }, // Auto add ั
       { correct: CharState.Wrong, char: "x" },
       { correct: CharState.Wrong, char: "x" },
       { correct: CharState.Wrong, char: "x" },
@@ -148,6 +148,21 @@ describe("validateWord", () => {
         { correct: CharState.OutOfPlace, char: "ร" },
         { correct: CharState.Wrong, char: "ร" },
         { correct: CharState.Wrong, char: "ย์" },
+      ]
+      expect(validateWord(input, solution)).toEqual(expectedOutput)
+    })
+
+    it("strips all upper-lower characters of out-of-place characters", () => {
+      const input = "นักเรียน"
+      const solution = "ประเทศ"
+
+      const expectedOutput = [
+        { correct: CharState.Wrong, char: "นั" },
+        { correct: CharState.Wrong, char: "ก" },
+        { correct: CharState.OutOfPlace, char: "เ" },
+        { correct: CharState.OutOfPlace, char: "ร" }, // This one
+        { correct: CharState.Wrong, char: "ย" },
+        { correct: CharState.Wrong, char: "น" },
       ]
       expect(validateWord(input, solution)).toEqual(expectedOutput)
     })

--- a/src/lib/Wordle.test.ts
+++ b/src/lib/Wordle.test.ts
@@ -152,6 +152,21 @@ describe("validateWord", () => {
       expect(validateWord(input, solution)).toEqual(expectedOutput)
     })
 
+    it("auto corrects in-place character", () => {
+      const input = "กรุงเทพ"
+      const solution = "ประเทศ"
+
+      const expectedOutput = [
+        { correct: CharState.Wrong, char: "ก" },
+        { correct: CharState.Correct, char: "ร" }, // Auto-corrected
+        { correct: CharState.Wrong, char: "ง" },
+        { correct: CharState.Correct, char: "เ" },
+        { correct: CharState.Correct, char: "ท" },
+        { correct: CharState.Wrong, char: "พ" },
+      ]
+      expect(validateWord(input, solution)).toEqual(expectedOutput)
+    })
+
     it("strips all upper-lower characters of out-of-place characters", () => {
       const input = "นักเรียน"
       const solution = "ประเทศ"

--- a/src/lib/Wordle.ts
+++ b/src/lib/Wordle.ts
@@ -42,12 +42,27 @@ export function validateWord(word: string, solution: string) {
     const sNormalized = solutionNormalizedSplitted[idx]
     const char = wordSplitted[idx]
     const cNormalized = wordNormalizedSplitted[idx]
+
+    // If matching character or normalized char, and in correct position
     if (char === s || char === sNormalized) {
       return { correct: CharState.Correct, char: s }
     } else if (
+      // If the solution has normalized char in other position, but only once
       solutionSplitted.includes(char) ||
       solutionNormalizedSplitted.includes(cNormalized)
     ) {
+      // Remove one matching char from solution, so that it cannot be matched again
+      const idx1 = solutionSplitted.indexOf(char)
+      const idx2 = solutionNormalizedSplitted.indexOf(cNormalized)
+
+      if (idx1 !== -1) {
+        solutionSplitted[idx1] = null
+      }
+
+      if (idx2 !== -1) {
+        solutionNormalizedSplitted[idx2] = null
+      }
+
       return { correct: CharState.OutOfPlace, char }
     } else {
       return { correct: CharState.Wrong, char }

--- a/src/lib/Wordle.ts
+++ b/src/lib/Wordle.ts
@@ -45,6 +45,9 @@ export function validateWord(word: string, solution: string) {
 
     // If matching character or normalized char, and in correct position
     if (char === s || char === sNormalized) {
+      solutionSplitted[idx] = null
+      solutionNormalizedSplitted[idx] = null
+
       return { correct: CharState.Correct, char: s }
     } else if (
       // If the solution has normalized char in other position, but only once
@@ -54,16 +57,22 @@ export function validateWord(word: string, solution: string) {
       // Remove one matching char from solution, so that it cannot be matched again
       const idx1 = solutionSplitted.indexOf(char)
       const idx2 = solutionNormalizedSplitted.indexOf(cNormalized)
+      let correctChar
 
       if (idx1 !== -1) {
+        correctChar = solutionSplitted[idx1]
+        console.log({ correctChar, idx1 })
         solutionSplitted[idx1] = null
-      }
+        solutionNormalizedSplitted[idx1] = null
+      } else if (idx2 !== -1) {
+        correctChar = solutionSplitted[idx2]
+        console.log({ correctChar, idx2 })
 
-      if (idx2 !== -1) {
+        solutionSplitted[idx2] = null
         solutionNormalizedSplitted[idx2] = null
       }
 
-      return { correct: CharState.OutOfPlace, char }
+      return { correct: CharState.OutOfPlace, char: correctChar }
     } else {
       return { correct: CharState.Wrong, char }
     }

--- a/src/lib/Wordle.ts
+++ b/src/lib/Wordle.ts
@@ -38,17 +38,17 @@ export function validateWord(word: string, solution: string) {
   const solutionSplitted = splitWord(solution)
   const solutionNormalizedSplitted = splitWord(normalizeWord(solution))
 
-  const output = solutionSplitted.map((s, idx) => {
+  const output = solutionSplitted.map((sChar, idx) => {
     const sNormalized = solutionNormalizedSplitted[idx]
     const char = wordSplitted[idx]
     const cNormalized = wordNormalizedSplitted[idx]
 
     // If matching character or normalized char, and in correct position
-    if (char === s || char === sNormalized) {
+    if (char === sChar || cNormalized === sNormalized) {
       solutionSplitted[idx] = null
       solutionNormalizedSplitted[idx] = null
 
-      return { correct: CharState.Correct, char: s }
+      return { correct: CharState.Correct, char: sChar }
     } else if (
       // If the solution has normalized char in other position, but only once
       solutionSplitted.includes(char) ||
@@ -61,12 +61,10 @@ export function validateWord(word: string, solution: string) {
 
       if (idx1 !== -1) {
         correctChar = solutionSplitted[idx1]
-        console.log({ correctChar, idx1 })
         solutionSplitted[idx1] = null
         solutionNormalizedSplitted[idx1] = null
       } else if (idx2 !== -1) {
         correctChar = solutionSplitted[idx2]
-        console.log({ correctChar, idx2 })
 
         solutionSplitted[idx2] = null
         solutionNormalizedSplitted[idx2] = null


### PR DESCRIPTION
- Fix multiple out of place characters
- Auto-correct out-of-place characters (marked yellow)
- Auto-correct in-place character (marked green)

Fixes #1

Example: 
![image](https://user-images.githubusercontent.com/248741/150359252-5507c797-468f-453c-bde9-a4f7913de792.png)

คำว่า `นักเรียน` จะถูกตัดสระอีออกจาก ร. เรือ เพื่อให้ไม่สับสนว่าคำนั้นมีสระอีอยู่หรือไม่
(ในอนาคตจะทำการ mark สระอีเป็น used แต่จะทำการ implement ตามมาทีหลัง)

![image](https://user-images.githubusercontent.com/248741/150361041-2959153f-722c-4920-859b-119a50209c6b.png)

กรุงเทพ auto-corrected to กรงเทพ
