### PR TITLE
Fix h1 blocking "วิธีเล่น" button click

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -234,7 +234,7 @@
       <span class="flex justify-center h-full"
         ><button on:click={() => (modalViewed = false)}>วิธีเล่น</button></span
       >
-      <h1 class="absolute text-center inset-x-0 top-4 leading-4 text-2xl text-red-400 mb-2">
+      <h1 class="absolute text-center inset-x-0 top-4 leading-4 text-2xl text-red-400 mb-2 pointer-events-none">
         <span>{title}</span>
       </h1>
       <span>&nbsp;</span>


### PR DESCRIPTION
h1 filled the header bar and prevented pointer events from reaching the button. This change fixed the problem.

![Screen Shot 2565-01-28 at 22 17 43](https://user-images.githubusercontent.com/10735822/151580712-ebcae1e9-5f81-46ca-8d59-a554eb0b7c63.png)

