### PR TITLE
Disable double-tap to zoom on touch device

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -338,7 +338,7 @@
   <!-- Layout -->
   <div class="layout my-4 w-full px-1 max-w-2xl">
     {#each currentRows as row, rowIndex}
-      <div class="w-full flex flex-row justify-center">
+      <div class="w-full flex flex-row justify-center touch-manipulation">
         {#each row as alphabet, alphabetIndex}
           <div class="flex-grow flex m-0.5 relative">
             <button


### PR DESCRIPTION
When spamming the backspace key on a touch device, it zooms in the screen instead of deleting characters.

Adding `touch-manipulation` <sup>[1]</sup> (`touch-action: manipulation;`) should solve this problem.

---

Wordle also has this behavior disabled.
![image](https://user-images.githubusercontent.com/684347/152087284-9e63b2c5-e6b8-41f7-90bc-7574823fc14e.png)
https://stackoverflow.com/a/47131647/606355

[1]: https://tailwindcss.com/docs/touch-action