### PR TITLE
Add game link to share text

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -203,7 +203,11 @@
 
     const score: string = (lose ? "X" : `${results.length}`) + `/${attemptLimit}`
 
-    navigator.clipboard.writeText(`#Thwordle ${dateIndex + 1} ${score}\n\n${results.join("\n")}`)
+    const shareLinkLine = `เล่นเกม ➡️ ${new URL(url).host}`
+
+    navigator.clipboard.writeText(
+      `#Thwordle ${dateIndex + 1} ${score}\n\n${results.join("\n")}\n\n${shareLinkLine}`
+    )
 
     copied = true
 


### PR DESCRIPTION
## Summary
- Append a final line with the game link to the copied share text.

## Test plan
- [ ] Finish a game
- [ ] Click Share
- [ ] Paste into a note/social app and confirm it ends with: `เล่นเกม ➡️ thwordle.vercel.app`

Made with [Cursor](https://cursor.com)